### PR TITLE
[FIX] 마지막 퀴즈 종료 후 해설 없이 바로 종료되는 문제

### DIFF
--- a/client/src/api/game/handle-game-message.ts
+++ b/client/src/api/game/handle-game-message.ts
@@ -41,7 +41,9 @@ export const handleGameMessage = (message: GameWebSocketMessage) => {
     }
 
     case "GAME_END": {
-      transition({ type: "GAME_END", gameEnd: message.payload });
+      setTimeout(() => {
+        transition({ type: "GAME_END", gameEnd: message.payload });
+      }, 3000);
       break;
     }
 


### PR DESCRIPTION
## 📄 작업 내용 요약
마지막 퀴즈 종료 후 해설 없이 바로 종료되는 문제를 해결했습니다.

## 🏷️ Release 라벨
<!-- main 머지용 PR이면 RELEASE: MAJOR / RELEASE: MINOR / RELEASE: PATCH 중 하나를 선택 -->

## 📎 Issue 번호
#153 
