### PR TITLE
[FIX] 봇 생성 불가 예외 처리 로직 수정 및 에러 코드 추가

### DIFF
--- a/sigkill-server/src/main/java/com/gulab/sigkillserver/domain/bot/service/BotOrchestrator.java
+++ b/sigkill-server/src/main/java/com/gulab/sigkillserver/domain/bot/service/BotOrchestrator.java
@@ -4,10 +4,7 @@ import static com.gulab.sigkillserver.domain.room.constant.RoomConstants.MAX_ROO
 import static com.gulab.sigkillserver.domain.room.constant.RoomConstants.MIN_ROOM_NUMBER;
 import static com.gulab.sigkillserver.domain.room.exception.PlayerErrorCode.PLAYER_NOT_IN_ANY_ROOM;
 import static com.gulab.sigkillserver.domain.room.exception.PlayerErrorCode.PLAYER_NOT_IN_ROOM;
-import static com.gulab.sigkillserver.domain.room.exception.RoomErrorCode.ONLY_HOST_CAN_ADD_BOT;
-import static com.gulab.sigkillserver.domain.room.exception.RoomErrorCode.ROOM_CLOSING;
-import static com.gulab.sigkillserver.domain.room.exception.RoomErrorCode.ROOM_FULL;
-import static com.gulab.sigkillserver.domain.room.exception.RoomErrorCode.ROOM_IN_GAME;
+import static com.gulab.sigkillserver.domain.room.exception.RoomErrorCode.CANNOT_CREATE_BOT;
 import static com.gulab.sigkillserver.domain.room.exception.RoomErrorCode.ROOM_NOT_FOUND;
 import static com.gulab.sigkillserver.domain.room.exception.RoomErrorCode.ROOM_NUMBER_ERROR;
 
@@ -37,7 +34,6 @@ import com.gulab.sigkillserver.domain.user.model.User;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicReference;
 import lombok.RequiredArgsConstructor;
@@ -74,6 +70,7 @@ public class BotOrchestrator {
     private final GamePlayerRepository gamePlayerRepository;
     private final WaitingBotRoomCleanupService waitingBotRoomCleanupService;
     private final SimpMessagingTemplate messagingTemplate;
+
     @Qualifier("botTaskScheduler")
     private final TaskScheduler botTaskScheduler;
 
@@ -254,16 +251,16 @@ public class BotOrchestrator {
 
     private void validateBotAddRequest(Room room, Player requester) {
         if (!room.getHostId().equals(requester.getUserId())) {
-            throw new CustomException(ONLY_HOST_CAN_ADD_BOT);
+            throw new CustomException(CANNOT_CREATE_BOT);
         }
         if (room.isClosing()) {
-            throw new CustomException(ROOM_CLOSING);
+            throw new CustomException(CANNOT_CREATE_BOT);
         }
         if (room.isInGame()) {
-            throw new CustomException(ROOM_IN_GAME);
+            throw new CustomException(CANNOT_CREATE_BOT);
         }
         if (playerRepository.countByRoomId(room.getRoomId()) >= room.getCapacity()) {
-            throw new CustomException(ROOM_FULL);
+            throw new CustomException(CANNOT_CREATE_BOT);
         }
     }
 

--- a/sigkill-server/src/main/java/com/gulab/sigkillserver/domain/room/exception/RoomErrorCode.java
+++ b/sigkill-server/src/main/java/com/gulab/sigkillserver/domain/room/exception/RoomErrorCode.java
@@ -19,6 +19,7 @@ public enum RoomErrorCode implements CustomErrorCodeInterface {
     ROOM_TITLE_INVALID(String.format("방 제목의 길이는 최대 %d자 입니다", MAX_TITLE_LENGTH), HttpStatus.BAD_REQUEST),
     ROOM_NOT_FOUND("방을 찾을 수 없습니다", HttpStatus.NOT_FOUND),
     ROOM_FULL("방이 가득 찼습니다", HttpStatus.CONFLICT),
+    CANNOT_CREATE_BOT("봇을 생성할 수 없습니다", HttpStatus.CONFLICT),
     ROOM_CLOSING("봇만 남아 곧 닫히는 방에는 입장할 수 없습니다", HttpStatus.CONFLICT),
     ROOM_IN_GAME("이미 게임이 진행 중인 방입니다", HttpStatus.CONFLICT),
     CANNOT_LEAVE_DURING_GAME("게임이 진행 중인 방에서는 나갈 수 없습니다", HttpStatus.CONFLICT),


### PR DESCRIPTION
## 📄 작업 내용 요약
봇 생성 시도 시, 방이 가득 찼을 때, ROOM_FULL 이 아닌 CANNOT_CREATE_BOT 을 응답하도록 수정했습니다. 이제 ROOM_FULL 은 방 목록에서 방 입장 시도시 방이 가득차서 입장에 실패한 경우에만 응답됩니다.

## 🏷️ Release 라벨
<!-- main 머지용 PR이면 RELEASE: MAJOR / RELEASE: MINOR / RELEASE: PATCH 중 하나를 선택 -->

## 📎 Issue 번호
<!-- closed #번호 -->
